### PR TITLE
Tailwind 3.2.2 is fast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "devDependencies": {
         "autoprefixer": "^10.4.13",
         "postcss": "^8.4.20",
-        "tailwindcss": "^3.2.4",
+        "tailwindcss": "3.2.2",
         "vite": "^4.0.0"
       }
     },
@@ -1251,9 +1251,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
-      "integrity": "sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.2.tgz",
+      "integrity": "sha512-c2GtSdqg+harR4QeoTmex0Ngfg8IIHNeLQH5yr2B9uZbZR1Xt1rYbjWOWTcj3YLTZhrmZnPowoQDbSRFyZHQ5Q==",
       "dev": true,
       "dependencies": {
         "arg": "^5.0.2",
@@ -2130,9 +2130,9 @@
       "dev": true
     },
     "tailwindcss": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
-      "integrity": "sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.2.tgz",
+      "integrity": "sha512-c2GtSdqg+harR4QeoTmex0Ngfg8IIHNeLQH5yr2B9uZbZR1Xt1rYbjWOWTcj3YLTZhrmZnPowoQDbSRFyZHQ5Q==",
       "dev": true,
       "requires": {
         "arg": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.20",
-    "tailwindcss": "^3.2.4",
+    "tailwindcss": "3.2.2",
     "vite": "^4.0.0"
   }
 }


### PR DESCRIPTION
Fixes regression of 3.2.3 – [ref](https://github.com/tailwindlabs/tailwindcss/pull/9787#issuecomment-1355159071)

To test

- switch to `main` branch of this repo, do `npm install` and run `npm run dev` and open http://localhost:5173/ in browser
- open browser dev tools, network tab, filter for `tailwind.css`
- add / remove / change class in `main.js`
- observe `tailwind.css` request taking lots of time
- now switch to this branch `tw-3.2.2`, do `npm install` and repeat steps above; now `tailwind.css` request takes much less time